### PR TITLE
wikipediaから単語の概要を取得するscriptの追加

### DIFF
--- a/scripts/teach-me.coffee
+++ b/scripts/teach-me.coffee
@@ -17,6 +17,7 @@ module.exports = (robot) ->
         titles: word
         exchars: 130
         explaintext: 1
+        redirects: 1
         prop: 'extracts'
       })
       .get() (err, res, body) ->


### PR DESCRIPTION
hubot teach me <word> で<word>に書かれた単語の概要をwikipediaから取得するscriptです。
