### PR TITLE
YouTubeの動画が検索できない問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "hubot-scripts": "^2.5.16",
     "hubot-shipit": "^0.1.2",
     "hubot-slack": "^3.2.1",
-    "hubot-youtube": "^0.1.2"
+    "hubot-youtube": "github:mikoim/hubot-youtube"
   },
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
Herokuの環境変数でYouTube APIのトークンを設定する必要があります．

export YOUTUBE_API_KEY=hanamogera
